### PR TITLE
Show XSD metadata separately

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
     <h1>XSD Visualizer</h1>
     <p></p>
     <input type="file" id="fileInput" accept=".xsd,.xml" />
+    <div id="info">
+      <div id="description"></div>
+      <div id="types"></div>
+    </div>
     <div id="tree"></div>
     <script src="main.js"></script>
   </body>

--- a/main.js
+++ b/main.js
@@ -67,6 +67,38 @@ function collectGlobalTypes(xsdDoc) {
   });
   Object.assign(xsdGlobalTypes, xsdSimpleTypes, xsdComplexTypes);
 }
+function getSchemaDocumentation(xsdDoc) {
+  const schema = xsdDoc.getElementsByTagNameNS('*','schema')[0];
+  if (!schema) return '';
+  for (let c of schema.children || []) {
+    if (c.tagName && c.tagName.match(/annotation$/i)) {
+      for (let d of c.children || []) {
+        if (d.tagName && d.tagName.match(/documentation$/i)) {
+          return d.textContent.trim();
+        }
+      }
+    }
+  }
+  return '';
+}
+function renderTypesOverview() {
+  const typesDiv = document.getElementById('types');
+  if (!typesDiv) return;
+  const simple = Object.keys(xsdSimpleTypes);
+  const complex = Object.keys(xsdComplexTypes);
+  let html = '';
+  if (simple.length) {
+    html += '<h3>Simple Types</h3><ul>';
+    for (let t of simple) html += `<li>${t}</li>`;
+    html += '</ul>';
+  }
+  if (complex.length) {
+    html += '<h3>Complex Types</h3><ul>';
+    for (let t of complex) html += `<li>${t}</li>`;
+    html += '</ul>';
+  }
+  typesDiv.innerHTML = html;
+}
 function parseXsdNode(elem, parentChoice=false, parentPath='', typeDepth=0) {
   if (!elem || !elem.tagName) return null;
   const tag = elem.tagName.replace(/^.*:/, '');
@@ -311,6 +343,8 @@ document.getElementById('fileInput').addEventListener('change', function(evt) {
       return;
     }
     collectGlobalTypes(xsdDoc);
+    document.getElementById('description').textContent = getSchemaDocumentation(xsdDoc);
+    renderTypesOverview();
     const rootElements = extractRootNodes(xsdDoc);
     if (rootElements.length===0) {
       document.getElementById('tree').innerHTML = "<b>No global elements found.</b>";

--- a/style.css
+++ b/style.css
@@ -8,6 +8,21 @@ h1 {
   margin-top: 0;
   font-size: 1.5em;
 }
+#info {
+  margin-top: 1.1em;
+  max-width: 1700px;
+}
+#description, #types {
+  background: #fff;
+  border: 1px solid #dce3ec;
+  border-radius: 8px;
+  padding: 0.6em 1em;
+  margin-bottom: 0.8em;
+}
+#types ul {
+  margin: 0;
+  padding-left: 1.2em;
+}
 #tree {
   margin-top: 1.1em;
   max-width: 1700px;


### PR DESCRIPTION
## Summary
- Display schema description and global types in a new info section
- Style metadata section to appear above the tree view
- Render description and types after reading the XSD file

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_689c24e8be1083268747f6f8c4b470b3